### PR TITLE
Handle absent proceses in SCALE file

### DIFF
--- a/lib/task-runner
+++ b/lib/task-runner
@@ -15,10 +15,11 @@ cat "$PROCFILE" | while read line; do
   fi
   TASK=${line%%:*}
   if [ -f "$SCALEFILE" ]; then
-    SCALE=$(egrep "^$TASK=" "$SCALEFILE")
-    if [ -n "$SCALE" ]; then
-      NUM_PROCS=${SCALE#*=}
+    SCALE=$(egrep "^$TASK=" "$SCALEFILE" || true)
+    if [ -z "$SCALE" ]; then
+      continue
     fi
+    NUM_PROCS=${SCALE#*=}
     if [ "$NUM_PROCS" -eq 0 ]; then
       echo "=====> running task ${TASK}"
       CMD=$(ruby -e "require 'yaml';puts YAML.load_file('Procfile')['${TASK}']")


### PR DESCRIPTION
Because `errexit` is set, and `grep` returns a non-zero exit status when the match fails, absent processes in the SCALE file cause the deploy to fail.

I have changed the logic so that Procfile processes not present in the SCALE file are ignored.
