### PR TITLE
Call docker-args plugins before running containers

### DIFF
--- a/pre-deploy
+++ b/pre-deploy
@@ -16,7 +16,8 @@ fi
 copy_to_container "$PLUGIN_DIR/lib/task-runner" /build/task-runner
 
 echo "-----> Injecting App Task Runner ..."
-id=$(docker run -d -v $CACHE_DIR:/cache $IMAGE /bin/bash -c "/bin/bash /build/task-runner")
+DOCKER_ARGS=$(: | pluginhook docker-args $APP)
+id=$(docker run -d -v $CACHE_DIR:/cache $DOCKER_ARGS $IMAGE /bin/bash -c "/bin/bash /build/task-runner")
 docker attach $id
 test $(docker wait $id) -eq 0
 docker commit $id $IMAGE > /dev/null


### PR DESCRIPTION
The reason for this is that I connect to both MySQL & Docker via a socket which I mount using a volume, so I set the following docker args:

```
-v /var/run/mysqld/mysqld.sock:/var/run/mysqld/mysqld.sock
-v /var/run/docker.sock:/var/run/docker.sock
```

My pre deploy tasks (one being `rake db:migrate`) need these args to be able to run.
